### PR TITLE
Adjust Munki pkginfo descriptions

### DIFF
--- a/IPVanish/IPVanish VPN.munki.recipe
+++ b/IPVanish/IPVanish VPN.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>IPVanish provides a secure environment for everyday internet activity. This recipe downloads the latest version of IPVanish VPN client and imports it into Munki.</string>
+	<string>This recipe downloads the latest version of IPVanish VPN client and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.Lotusshaney.munki.IPVanishVPN</string>
 	<key>Input</key>
@@ -19,7 +19,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string> </string>
+			<string>IPVanish provides a secure environment for everyday internet activity.</string>
 			<key>developer</key>
 			<string>Mudhook Marketing, Inc.</string>
 			<key>display_name</key>

--- a/Murus/murus.munki.recipe
+++ b/Murus/murus.munki.recipe
@@ -19,7 +19,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string>Murus PF Firewallt</string>
+			<string>Front-end for macOS packet filter firewall.</string>
 			<key>display_name</key>
 			<string>Murus</string>
 			<key>name</key>

--- a/No-IP DUC/No-IP DUC.munki.recipe
+++ b/No-IP DUC/No-IP DUC.munki.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Keep your current IP address in sync with your No-IP host or domain with the Dynamic Update Client (DUC). This recipe downloads the latest version of No-IP DUC and imports it into Munki.</string>
+	<string>This recipe downloads the latest version of No-IP DUC and imports it into Munki.</string>
 	<key>Identifier</key>
 	<string>com.github.Lotusshaney.munki.No-IPDUC</string>
 	<key>Input</key>
@@ -19,7 +19,7 @@
 				<string>testing</string>
 			</array>
 			<key>description</key>
-			<string> </string>
+			<string>Keep your current IP address in sync with your No-IP host or domain with the Dynamic Update Client (DUC).</string>
 			<key>developer</key>
 			<string>Vitalwerks Internet Solutions, LLC</string>
 			<key>display_name</key>


### PR DESCRIPTION
This PR adjusts the Munki descriptions that will be shown to users in MSC when updates to these apps are available. These descriptions are meant to be separate from the top-level `Description` key that is intended for AutoPkg recipe users.