### PR TITLE
Create pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+  - repo: https://github.com/homebysix/pre-commit-macadmin
+    rev: v1.12.3
+    hooks:
+      - id: check-autopkg-recipes
+        args: ["--recipe-prefix=com.github.Lotusshaney.", "--strict", "--"]
+      - id: forbid-autopkg-overrides
+      - id: forbid-autopkg-trust-info


### PR DESCRIPTION
This PR adds a pre-commit configuration tailored to AutoPkg recipes, and this repository specifically.

To use this configuration, install pre-commit on your Mac (e.g. using `brew install pre-commit`), then `cd` to this repo and run `pre-commit install`. From that point on, each test in the config file must pass in order for a commit to be written.

Because this configuration lives in a file in the repo itself, it will be shared by any other contributors who have pre-commit installed, making it easy to ensure everybody's running the same tests.

Some more details and examples in this quick talk from MacDevOpsYVR: https://www.youtube.com/watch?v=1UCyGC6DVOU