### PR TITLE
Adjust parent recipes that reference killahquam-recipes

### DIFF
--- a/Slack/Slack.munki.recipe
+++ b/Slack/Slack.munki.recipe
@@ -35,7 +35,7 @@
 	<key>MinimumVersion</key>
 	<string>0.2.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.killahquam.pkg.slack</string>
+	<string>com.github.rtrouton.pkg.SlackUniversal</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Visual Studio Code/Visual Studio Code.munki.recipe
+++ b/Visual Studio Code/Visual Studio Code.munki.recipe
@@ -37,7 +37,7 @@
 		<key>MinimumVersion</key>
 		<string>0.2.0</string>
 		<key>ParentRecipe</key>
-		<string>com.github.killahquam.pkg.visualstudioscode</string>
+		<string>com.github.amsysuk-recipes.pkg.VisualStudioCode</string>
 		<key>Process</key>
 		<array>
 			<dict>


### PR DESCRIPTION
The recipes in killahquam-recipes have been deprecated and will be removed soon. (See https://github.com/autopkg/killahquam-recipes/issues/28 for details.)

This pull request adjusts the parents for recipes that reference killahquam-recipes. The parents have been changed to actively maintained recipes in other repos.