### PR TITLE
Don't remove `Zoom` directory as it's required for `munki`

### DIFF
--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -110,7 +110,6 @@
 				<key>path_list</key>
 				<array>
 					<string>%RECIPE_CACHE_DIR%/expanded</string>
-					<string>%RECIPE_CACHE_DIR%/Zoom</string>
 				</array>
 			</dict>
 			<key>Processor</key>


### PR DESCRIPTION
The `Zoom` directory is used by the `munki` recipe to create an `installs` key.