### PR TITLE
Deprecate Firefox recipes

### DIFF
--- a/Mozilla Corporation/Firefox-ESR.download.recipe
+++ b/Mozilla Corporation/Firefox-ESR.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Firefox recipes in the autopkg/recipes repo and setting the RELEASE input variable to "esr-latest" in your recipe override. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>

--- a/Mozilla Corporation/Firefox.download.recipe
+++ b/Mozilla Corporation/Firefox.download.recipe
@@ -16,6 +16,15 @@
 	<key>Process</key>
 	<array>
 		<dict>
+			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Consider switching to the Firefox recipes in the autopkg/recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>


### PR DESCRIPTION
The Firefox and Firefox-ESR recipes in this repo are redundant with the ones that have been offered by the autopkg/recipes repo for many years. This PR deprecates the Firefox recipes and points users to the autopkg/recipes alternatives.
