### PR TITLE
Change parent of PodmanDesktop pkg recipe, deprecate download recipe

### DIFF
--- a/Podman Desktop/Podman Desktop.download.recipe
+++ b/Podman Desktop/Podman Desktop.download.recipe
@@ -15,6 +15,15 @@
 	<string>2.3</string>
 	<key>Process</key>
 	<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the PodmanDesktop recipes in the apettinen-recipes or gregneagle-recipes repos. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Podman Desktop/Podman Desktop.munki.recipe
+++ b/Podman Desktop/Podman Desktop.munki.recipe
@@ -33,7 +33,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.Lotusshaney.download.PodmanDesktop</string>
+	<string>com.github.peshay.download.draw.io</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Podman Desktop/Podman Desktop.munki.recipe
+++ b/Podman Desktop/Podman Desktop.munki.recipe
@@ -33,7 +33,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.peshay.download.draw.io</string>
+	<string>com.github.autopkg.gregneagle-recipes.download.PodmanDesktop</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Podman Desktop/Podman Desktop.pkg.recipe
+++ b/Podman Desktop/Podman Desktop.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.peshay.download.draw.io</string>
+	<string>com.github.autopkg.gregneagle-recipes.download.PodmanDesktop</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/Podman Desktop/Podman Desktop.pkg.recipe
+++ b/Podman Desktop/Podman Desktop.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>2.3</string>
 	<key>ParentRecipe</key>
-	<string>com.github.Lotusshaney.download.PodmanDesktop</string>
+	<string>com.github.peshay.download.draw.io</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This PR changes the parent recipes for the PodmanDesktop pkg and munki recipes in this repo, and deprecates the PodmanDesktop download recipe.

Verbose recipe run output:

```
% autopkg run -vvq Podman\ Desktop.{pkg,munki}.recipe
Processing Podman Desktop.pkg.recipe...
WARNING: Podman Desktop.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(draw.io-universal-.*?\\.dmg)$',
           'github_repo': 'jgraph/drawio-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(draw.io-universal-.*?\.dmg)$' among asset(s): draw.io-25.0.2-windows-installer.exe, draw.io-25.0.2-windows-installer.exe.blockmap, draw.io-25.0.2-windows-no-installer.exe, draw.io-25.0.2.msi, draw.io-arm64-25.0.2-windows-arm64-installer.exe, draw.io-arm64-25.0.2-windows-arm64-installer.exe.blockmap, draw.io-arm64-25.0.2-windows-arm64-no-installer.exe, draw.io-arm64-25.0.2.dmg, draw.io-arm64-25.0.2.dmg.blockmap, draw.io-arm64-25.0.2.zip, draw.io-arm64-25.0.2.zip.blockmap, draw.io-ia32-25.0.2-windows-32bit-installer.exe, draw.io-ia32-25.0.2-windows-32bit-installer.exe.blockmap, draw.io-ia32-25.0.2-windows-32bit-no-installer.exe, draw.io-universal-25.0.2.dmg, draw.io-universal-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.dmg, draw.io-x64-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.zip, draw.io-x64-25.0.2.zip.blockmap, drawio-aarch64-25.0.2.rpm, drawio-amd64-25.0.2.deb, drawio-arm64-25.0.2.AppImage, drawio-arm64-25.0.2.deb, drawio-x86_64-25.0.2.AppImage, drawio-x86_64-25.0.2.rpm, latest-linux-arm64.yml, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'draw.io-universal-25.0.2.dmg' from release '25.0.2'
{'Output': {'asset_created_at': '2024-12-03T11:28:54Z',
            'asset_url': 'https://api.github.com/repos/jgraph/drawio-desktop/releases/assets/210719593',
            'release_notes': '## Releases Notes for 25.0.2\r\n'
                             '[Windows '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-installer.exe)\r\n'
                             '[Windows No '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-no-installer.exe)\r\n'
                             '[macOS - '
                             'Universal](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg)\r\n'
                             'Linux - '
                             '[deb](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-amd64-25.0.2.deb), '
                             '[AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.AppImage) '
                             'or '
                             '[rpm](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.rpm)\r\n'
                             '\r\n'
                             'Windows intel x32 releases are marked -ia32-\r\n'
                             '\r\n'
                             '**ChangeLog:**\r\n'
                             '\r\n'
                             '- #1922 \r\n'
                             '- Updates to draw.io core 25.0.2\r\n'
                             '- Uses electron 32.2.5\r\n'
                             '- Updates to [draw.io core '
                             '25.0.2](https://github.com/jgraph/drawio/blob/v25.0.2/ChangeLog). '
                             'All changes from 25.0.2 are added in this build.',
            'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg',
            'version': '25.0.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 03 Dec 2024 11:29:09 GMT
URLDownloader: Storing new ETag header: "0x8DD138DB43DDB5E"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD138DB43DDB5E"',
            'last_modified': 'Tue, 03 Dec 2024 11:29:09 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg/draw.io.app',
           'requirement': 'identifier "com.jgraph.drawio.desktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UZEUFB4N53'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.UXib5b/draw.io.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.UXib5b/draw.io.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.UXib5b/draw.io.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
AppPkgCreator
{'Input': {'version': '25.0.2'}}
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
AppPkgCreator: Using path '/private/tmp/dmg.7lBlCs/draw.io.app' matched from globbed '/private/tmp/dmg.7lBlCs/*.app'.
AppPkgCreator: BundleID: com.jgraph.drawio.desktop
AppPkgCreator: Copied /private/tmp/dmg.7lBlCs/draw.io.app to ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/payload/Applications/draw.io.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
AppPkgCreator: Failed to close socket: [Errno 9] Bad file descriptor
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'com.jgraph.drawio.desktop',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/draw.io-25.0.2.pkg',
                                                        'version': '25.0.2'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '25.0.2'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/receipts/Podman Desktop.pkg-receipt-20250101-113435.plist
Processing Podman Desktop.munki.recipe...
WARNING: Podman Desktop.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '(draw.io-universal-.*?\\.dmg)$',
           'github_repo': 'jgraph/drawio-desktop'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '(draw.io-universal-.*?\.dmg)$' among asset(s): draw.io-25.0.2-windows-installer.exe, draw.io-25.0.2-windows-installer.exe.blockmap, draw.io-25.0.2-windows-no-installer.exe, draw.io-25.0.2.msi, draw.io-arm64-25.0.2-windows-arm64-installer.exe, draw.io-arm64-25.0.2-windows-arm64-installer.exe.blockmap, draw.io-arm64-25.0.2-windows-arm64-no-installer.exe, draw.io-arm64-25.0.2.dmg, draw.io-arm64-25.0.2.dmg.blockmap, draw.io-arm64-25.0.2.zip, draw.io-arm64-25.0.2.zip.blockmap, draw.io-ia32-25.0.2-windows-32bit-installer.exe, draw.io-ia32-25.0.2-windows-32bit-installer.exe.blockmap, draw.io-ia32-25.0.2-windows-32bit-no-installer.exe, draw.io-universal-25.0.2.dmg, draw.io-universal-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.dmg, draw.io-x64-25.0.2.dmg.blockmap, draw.io-x64-25.0.2.zip, draw.io-x64-25.0.2.zip.blockmap, drawio-aarch64-25.0.2.rpm, drawio-amd64-25.0.2.deb, drawio-arm64-25.0.2.AppImage, drawio-arm64-25.0.2.deb, drawio-x86_64-25.0.2.AppImage, drawio-x86_64-25.0.2.rpm, latest-linux-arm64.yml, latest-linux.yml, latest-mac.yml, latest.yml
GitHubReleasesInfoProvider: Selected asset 'draw.io-universal-25.0.2.dmg' from release '25.0.2'
{'Output': {'asset_created_at': '2024-12-03T11:28:54Z',
            'asset_url': 'https://api.github.com/repos/jgraph/drawio-desktop/releases/assets/210719593',
            'release_notes': '## Releases Notes for 25.0.2\r\n'
                             '[Windows '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-installer.exe)\r\n'
                             '[Windows No '
                             'Installer](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-25.0.2-windows-no-installer.exe)\r\n'
                             '[macOS - '
                             'Universal](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg)\r\n'
                             'Linux - '
                             '[deb](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-amd64-25.0.2.deb), '
                             '[AppImage](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.AppImage) '
                             'or '
                             '[rpm](https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/drawio-x86_64-25.0.2.rpm)\r\n'
                             '\r\n'
                             'Windows intel x32 releases are marked -ia32-\r\n'
                             '\r\n'
                             '**ChangeLog:**\r\n'
                             '\r\n'
                             '- #1922 \r\n'
                             '- Updates to draw.io core 25.0.2\r\n'
                             '- Uses electron 32.2.5\r\n'
                             '- Updates to [draw.io core '
                             '25.0.2](https://github.com/jgraph/drawio/blob/v25.0.2/ChangeLog). '
                             'All changes from 25.0.2 are added in this build.',
            'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg',
            'version': '25.0.2'}}
URLDownloader
{'Input': {'url': 'https://github.com/jgraph/drawio-desktop/releases/download/v25.0.2/draw.io-universal-25.0.2.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 03 Dec 2024 11:29:09 GMT
URLDownloader: Storing new ETag header: "0x8DD138DB43DDB5E"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD138DB43DDB5E"',
            'last_modified': 'Tue, 03 Dec 2024 11:29:09 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg/draw.io.app',
           'requirement': 'identifier "com.jgraph.drawio.desktop" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'UZEUFB4N53'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.a7T1kE/draw.io.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.a7T1kE/draw.io.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.a7T1kE/draw.io.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'Podman Desktop - A graphical tool for '
                                      'developing on containers and Kubernetes',
                       'developer': 'Red Hat',
                       'display_name': 'Podman Desktop',
                       'name': 'Podman Desktop',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/Podman Desktop'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/Podman Desktop/Podman Desktop-25.0.2.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/Podman Desktop/draw.io-universal-25.0.2.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'Podman Desktop',
                                                       'pkg_repo_path': 'apps/Podman '
                                                                        'Desktop/draw.io-universal-25.0.2.dmg',
                                                       'pkginfo_path': 'apps/Podman '
                                                                       'Desktop/Podman '
                                                                       'Desktop-25.0.2.plist',
                                                       'version': '25.0.2'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2025, 1, 1, 19, 34, 48),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'Podman Desktop - A graphical tool '
                                          'for developing on containers and '
                                          'Kubernetes',
                           'developer': 'Red Hat',
                           'display_name': 'Podman Desktop',
                           'installer_item_hash': 'ab9c5bcea90ca3080fbc0f4195b768475a4acb17a2bf541b892dd259aac81559',
                           'installer_item_location': 'apps/Podman '
                                                      'Desktop/draw.io-universal-25.0.2.dmg',
                           'installer_item_size': 210318,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.jgraph.drawio.desktop',
                                         'CFBundleName': 'draw.io',
                                         'CFBundleShortVersionString': '25.0.2',
                                         'CFBundleVersion': '25.0.2',
                                         'minosversion': '10.15',
                                         'path': '/Applications/draw.io.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'draw.io.app'}],
                           'minimum_os_version': '10.15',
                           'name': 'Podman Desktop',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '25.0.2'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/Podman '
                             'Desktop/draw.io-universal-25.0.2.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/Podman '
                                 'Desktop/Podman Desktop-25.0.2.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/receipts/Podman Desktop.munki-receipt-20250101-113448.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg
    ~/Library/AutoPkg/Cache/com.github.Lotusshaney.munki.PodmanDesktop/downloads/draw.io-universal-25.0.2.dmg

The following packages were built:
    Identifier                 Version  Pkg Path
    ----------                 -------  --------
    com.jgraph.drawio.desktop  25.0.2   ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.PodmanDesktop/draw.io-25.0.2.pkg

The following new items were imported into Munki:
    Name            Version  Catalogs  Pkginfo Path                                     Pkg Repo Path                                     Icon Repo Path
    ----            -------  --------  ------------                                     -------------                                     --------------
    Podman Desktop  25.0.2   testing   apps/Podman Desktop/Podman Desktop-25.0.2.plist  apps/Podman Desktop/draw.io-universal-25.0.2.dmg
```