### PR TITLE
Update AdobeCreativeCloudInstallerUniversal.download.recipe with new URL

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -18,7 +18,7 @@
 		<key>NAMEWITHOUTSPACES</key>
 		<string>CreativeCloudInstaller</string>
 		<key>SEARCH_URL</key>
-		<string>https://helpx.adobe.com/download-install/kb/creative-cloud-desktop-app-download.html</string>
+		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>INTEL_SEARCH_PATTERN</key>
 		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>APPLE_SILICON_SEARCH_PATTERN</key>


### PR DESCRIPTION
I copied the URL change from `rtrouton`'s recent updates to his recipe, and it worked with this one.

https://github.com/autopkg/rtrouton-recipes/commit/bfa848c7bc8204ee7034d659f4022501c6733c0a