### PR TITLE
Removal of unused `options` from PkgCreator arguments

### DIFF
--- a/1Password8/1Password8.pkg.recipe
+++ b/1Password8/1Password8.pkg.recipe
@@ -194,8 +194,6 @@ exit 0
 						<string>%RECIPE_CACHE_DIR%/Scripts</string>
 						<key>pkgroot</key>
 						<string>%RECIPE_CACHE_DIR%/payload</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 					</dict>
 				</dict>
 			</dict>

--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.pkg.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.pkg.recipe
@@ -360,8 +360,6 @@ exit 0</string>
                   <string>com.adobe.AdobeCreativeCloudInstallerUniversal</string>
                   <key>scripts</key>
                   <string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-                  <key>options</key>
-                  <string>purge_ds_store</string>
                </dict>
             </dict>
          </dict>

--- a/Nextcloud/Nextcloud.pkg.recipe
+++ b/Nextcloud/Nextcloud.pkg.recipe
@@ -197,8 +197,6 @@ exit 0
 						<string>%RECIPE_CACHE_DIR%/Scripts</string>
 						<key>pkgroot</key>
 						<string>%RECIPE_CACHE_DIR%/payload</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 					</dict>
 				</dict>
 			</dict>

--- a/No-IP DUC/No-IP DUC.pkg.recipe
+++ b/No-IP DUC/No-IP DUC.pkg.recipe
@@ -62,8 +62,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>pkgroot</key>

--- a/SmallStep/step_cli_uni.pkg.recipe
+++ b/SmallStep/step_cli_uni.pkg.recipe
@@ -354,8 +354,6 @@ exit 0
           <dict>
             <key>id</key>
             <string>com.github.smallstep.step.universal</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>pkgname</key>
             <string>%NAME%-Universal-%version%</string>
             <key>scripts</key>

--- a/SmallStep/step_kms_uni.pkg.recipe
+++ b/SmallStep/step_kms_uni.pkg.recipe
@@ -354,8 +354,6 @@ exit 0
           <dict>
             <key>id</key>
             <string>com.github.smallstep.stepkms.universal</string>
-            <key>options</key>
-            <string>purge_ds_store</string>
             <key>pkgname</key>
             <string>%NAME%-Universal-%version%</string>
             <key>scripts</key>

--- a/Tailscale/Tailscale.pkg.recipe
+++ b/Tailscale/Tailscale.pkg.recipe
@@ -167,8 +167,6 @@ exit 0
 						<string>%RECIPE_CACHE_DIR%/Scripts</string>
 						<key>pkgroot</key>
 						<string>%RECIPE_CACHE_DIR%/payload</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 					</dict>
 				</dict>
 			</dict>

--- a/Tailscale_unstable/Tailscale_unstable.pkg.recipe
+++ b/Tailscale_unstable/Tailscale_unstable.pkg.recipe
@@ -167,8 +167,6 @@ exit 0
 						<string>%RECIPE_CACHE_DIR%/Scripts</string>
 						<key>pkgroot</key>
 						<string>%RECIPE_CACHE_DIR%/payload</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 					</dict>
 				</dict>
 			</dict>

--- a/Wireshark-Universal/Wireshark-Universal.pkg.recipe
+++ b/Wireshark-Universal/Wireshark-Universal.pkg.recipe
@@ -101,8 +101,6 @@ exit 0</string>
 						</array>
 						<key>id</key>
 						<string>org.wireshark.Wireshark.pkg</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
 						<key>scripts</key>
@@ -198,8 +196,6 @@ exit 0</string>
 						</array>
 						<key>id</key>
 						<string>org.wireshark.Wireshark.pkg</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
 					</dict>
@@ -313,8 +309,6 @@ exit 0</string>
 						<string>org.wireshark.WiresharkInstallerUniversal</string>
 						<key>scripts</key>
 						<string>%RECIPE_CACHE_DIR%/Universal/Scripts</string>
-						<key>options</key>
-						<string>purge_ds_store</string>
 					</dict>
 				</dict>
 			</dict>

--- a/Zoom/Zoom.pkg.recipe
+++ b/Zoom/Zoom.pkg.recipe
@@ -91,8 +91,6 @@
 					</array>
 					<key>id</key>
 					<string>%BUNDLE_ID%</string>
-					<key>options</key>
-					<string>purge_ds_store</string>
 					<key>pkgname</key>
 					<string>%NAME%-%version%</string>
 					<key>scripts</key>


### PR DESCRIPTION
Hundreds of recipes dating from the very beginning of AutoPkg use the `options` key in the `pkg_request` argument of PkgCreator:

```xml
<key>options</key>
<string>purge_ds_store</string>
```

However, this key doesn't serve any purpose at all. The `options` key is ignored and not passed along to `pkgbuild`, regardless of its presence or contents. It appears that this has been the case since the very first public release of AutoPkg 0.1.0!

So this pull request (one of over 100) formally ends this practice and removes the unused and unneeded `options` key from all recipes in the AutoPkg org that use PkgCreator.

Thanks for considering!

_This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.2.0._