### PR TITLE
Adjust parent for tallfunnyjew-recipes deprecation

### DIFF
--- a/Telegram/Telegram-pkg.munki.recipe
+++ b/Telegram/Telegram-pkg.munki.recipe
@@ -37,7 +37,7 @@
         <key>MinimumVersion</key>
         <string>1.0.0</string>
         <key>ParentRecipe</key>
-        <string>com.github.tallfunnyjew.pkg.Telegram</string>
+        <string>com.github.moofit-recipes.pkg.Telegram</string>
         <key>Process</key>
         <array>
             <dict>


### PR DESCRIPTION
The tallfunnyjew-recipes repository [will be deprecated and archived](https://github.com/autopkg/tallfunnyjew-recipes/issues/37). This PR switches the Telegram-pkg.munki recipe parent recipe to a working copy in the moofit-recipes repository.