### PR TITLE
Deprecate Wireshark recipes

### DIFF
--- a/Wireshark-Universal/Wireshark-Universal.download.recipe
+++ b/Wireshark-Universal/Wireshark-Universal.download.recipe
@@ -12,9 +12,18 @@
 			<string>Wireshark</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>0.4.0</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the Wireshark recipes in the homebysix-recipes repo, which download a Universal version of the installer. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>


### PR DESCRIPTION
The Wireshark recipes in this repo, which separately download the Intel and Apple Silicon versions of Wireshark and then create a combined pkg for them, are no longer required. Wireshark offers a native Universal download, which the existing recipes in homebysix-recipes provide.