### PR TITLE
Change parent to peterkelm-recipes xca.download

### DIFF
--- a/xca/xca.download.recipe
+++ b/xca/xca.download.recipe
@@ -12,9 +12,18 @@
 		<string>xca</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to the xca recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/xca/xca.pkg.recipe
+++ b/xca/xca.pkg.recipe
@@ -14,7 +14,7 @@
 	<key>MinimumVersion</key>
 	<string>1.0.0</string>
 	<key>ParentRecipe</key>
-	<string>com.github.Lotusshaney.download.xca</string>
+	<string>com.github.peterkelm.download.xca</string>
 	<key>Process</key>
 	<array>
 		<dict>


### PR DESCRIPTION
This changes the parent of xca.pkg to the xca.download recipe in peterkelm-recipes, which was created before the equivalent download recipe in this repo.

This consolidation will help simplify search results and lower maintenance effort.

Adjusted xca.pkg recipe verbose output:

```
% autopkg run -vvq 'Lotusshaney-recipes/xca/xca.pkg.recipe'
Processing Lotusshaney-recipes/xca/xca.pkg.recipe...
WARNING: Lotusshaney-recipes/xca/xca.pkg.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
GitHubReleasesInfoProvider
{'Input': {'asset_regex': '.*\\.dmg$', 'github_repo': 'chris2511/xca'}}
GitHubReleasesInfoProvider: No value supplied for CURL_PATH, setting default value of: /usr/bin/curl
GitHubReleasesInfoProvider: No value supplied for GITHUB_URL, setting default value of: https://api.github.com
GitHubReleasesInfoProvider: No value supplied for GITHUB_TOKEN_PATH, setting default value of: ~/.autopkg_gh_token
GitHubReleasesInfoProvider: Matched regex '.*\.dmg$' among asset(s): xca-2.9.0-Darwin.dmg, xca-2.9.0-win64.msi, xca-2.9.0.tar.gz, xca-portable-2.9.0.zip
GitHubReleasesInfoProvider: Selected asset 'xca-2.9.0-Darwin.dmg' from release 'XCA 2.9.0'
{'Output': {'asset_created_at': '2025-03-28T20:41:35Z',
            'asset_url': 'https://api.github.com/repos/chris2511/xca/releases/assets/241678353',
            'release_notes': '# XCA - X Certificate and Key Management\r\n'
                             '\r\n'
                             '[![CMake](https://github.com/chris2511/xca/actions/workflows/cmake.yaml/badge.svg)](https://github.com/chris2511/xca/actions/workflows/cmake.yaml)\r\n'
                             '\r\n'
                             '## __Release Notes__\r\n'
                             '\r\n'
                             '* The latest release is *2.9.0*\r\n'
                             '* This release fixes some minor issues:\r\n'
                             '  * Improve remote database support on macosx\r\n'
                             '  * Do not revoke renewed certificate with same '
                             'serial\r\n'
                             '  * Fix default template finding on linux\r\n'
                             '  * Use latest OpenSSL and Qt releases for the '
                             'precompiled releases.\r\n'
                             '* Please report issues on github '
                             '<https://github.com/chris2511/xca/issues>\r\n'
                             '\r\n'
                             '## __Changelog:__\r\n'
                             '\r\n'
                             'A detailed changelog can be found here:\r\n'
                             '\r\n'
                             '<https://hohnstaedt.de/xca/index.php/software/changelog>\r\n'
                             '\r\n'
                             '## __Documentation__\r\n'
                             '\r\n'
                             'This application is documented in the *Help* '
                             'menu and here:\r\n'
                             '\r\n'
                             '<https://www.hohnstaedt.de/xca/index.php/documentation/manual>\r\n'
                             '\r\n'
                             '## __Build from Source__\r\n'
                             '\r\n'
                             '### Dependencies\r\n'
                             '\r\n'
                             'To build XCA you need:\r\n'
                             ' - a toolchain\r\n'
                             ' - cmake: https://cmake.org\r\n'
                             ' - Qt5 or Qt6: https://www.qt.io (5.10.1 or '
                             'higher)\r\n'
                             ' - OpenSSL: https://www.openssl.org (1.1.1 or '
                             'higher)\r\n'
                             '   or libressl-3.6.x\r\n'
                             ' - Sphinx-Build: https://www.sphinx-doc.org\r\n'
                             '\r\n'
                             '### Linux / Unix\r\n'
                             '\r\n'
                             ' - Install the dependencies\r\n'
                             '   ```\r\n'
                             '   # Bookworm\r\n'
                             '   sudo apt install build-essential libssl-dev '
                             'pkg-config cmake qttools5-dev '
                             'python3-sphinxcontrib.qthelp\r\n'
                             '   # Bullseye\r\n'
                             '   sudo apt install build-essential libssl-dev '
                             'pkg-config cmake qttools5-dev python3-sphinx\r\n'
                             '   # Either Qt5\r\n'
                             '   sudo apt install qtbase5-dev '
                             'qttools5-dev-tools libqt5sql5 libqt5help5 '
                             'qttools5-dev\r\n'
                             '   # Or Qt6\r\n'
                             '   sudo apt install qt6-base-dev '
                             'qt6-tools-dev\r\n'
                             '   ```\r\n'
                             ' - Clone: `git clone '
                             'https://github.com/chris2511/xca.git`\r\n'
                             ' - Configure: `cmake -B build xca`\r\n'
                             ' - Make: `cmake --build build -j5`\r\n'
                             ' - Install: `sudo cmake --install build`\r\n'
                             ' - Or install local and copy later as root: '
                             '`DESTDIR=DEST cmake --install build --prefix '
                             '/usr`\r\n'
                             '\r\n'
                             '### Apple macos\r\n'
                             '\r\n'
                             '- Install the dependencies\r\n'
                             '  ```\r\n'
                             '  xcode-select --install\r\n'
                             '  brew install openssl@3 qt6 python3 cmake\r\n'
                             '  pip3 install sphinx\r\n'
                             '  ```\r\n'
                             '- Clone: `git clone '
                             'https://github.com/chris2511/xca.git`\r\n'
                             '- Configure: `cmake -B build xca`\r\n'
                             '- Make: `cmake --build build -j5`\r\n'
                             '- Build the DMG: `cd build && cpack`\r\n'
                             '- Build the PKG: `cd build && cpack -G '
                             'productbuild`\r\n'
                             '\r\n'
                             'XCA can be used with Xcode after initializing '
                             'the directory with:\r\n'
                             '`cmake -G Xcode -B .`\r\n'
                             '\r\n'
                             '### Windows\r\n'
                             '\r\n'
                             '- Install the dependencies\r\n'
                             '  - Install Python 3.11 for windows from the '
                             'store or '
                             'https://www.python.org/downloads/windows/\r\n'
                             '  - Install OpenSSL from here: '
                             'https://slproweb.com/download/Win64OpenSSL-3_1_5.msi '
                             'and verify the sha256 from '
                             'https://github.com/slproweb/opensslhashes/blob/master/win32_openssl_hashes.json\r\n'
                             '  - To install the Qt libraries, cmake and the '
                             'MinGW compiler '
                             '[aqtinstall](https://github.com/miurahr/aqtinstall) '
                             'is used.\r\n'
                             '    Sphinx is used to generate the '
                             'documentation\r\n'
                             '    ```\r\n'
                             '    pip3 install sphinx aqtinstall\r\n'
                             '    ```\r\n'
                             '  - Add the PATH shown by pip to your PATH\r\n'
                             '  - Install Qt, cmake and the MinGW toolchain\r\n'
                             '    ```\r\n'
                             '    aqt install-qt windows desktop 6.6.3 '
                             'win64_mingw\r\n'
                             '    aqt install-tool windows desktop '
                             'tools_mingw90 qt.tools.win64_mingw900\r\n'
                             '    aqt install-tool windows desktop '
                             'tools_vcredist qt.tools.vcredist_64\r\n'
                             '    ```\r\n'
                             '  - If 7z is missing, install it from the store. '
                             '`7-Zip File Manager (unofficial)` or from '
                             '7-zip.org\r\n'
                             '  - Install the "vcredist\\\\vcredist_64.exe"\r\n'
                             '  - Add cmake, MinGW, OpenSSL and Qt6 to your '
                             'Path\r\n'
                             '    ```\r\n'
                             '    '
                             '%USERPROFILE%\\AppData\\Local\\Packages\\PythonSoftwareFoundation.Python.3.10_qbz5n2kfra8p0\\LocalCache\\local-packages\\Python310\\Scripts;\r\n'
                             '    '
                             '%USERPROFILE%\\AppData\\Local\\Microsoft\\WindowsApps;\r\n'
                             '    %USERPROFILE%\\Tools\\CMake_64\\bin;\r\n'
                             '    %USERPROFILE%\\Tools\\mingw_64\\bin;\r\n'
                             '    %USERPROFILE%\\6.6.3\\mingw_64\\bin;\r\n'
                             '    ```\r\n'
                             '  - Create `CMAKE_PREFIX_PATH` environment '
                             'variable:\r\n'
                             '    ```\r\n'
                             '    '
                             '%USERPROFILE%\\6.6.3\\mingw_64\\lib\\cmake\r\n'
                             '    ```\r\n'
                             '  - Install `https://wixtoolset.org/releases/` '
                             'if you want to create the MSI installer\r\n'
                             '\r\n'
                             '- Clone: `git clone '
                             'https://github.com/chris2511/xca.git`\r\n'
                             '- Configure: `cmake -B build -G "MinGW '
                             'Makefiles" xca`\r\n'
                             '- Make: `cmake --build build -j5`\r\n'
                             '- Create the Portable App: `cmake --build build '
                             '-t install`\r\n'
                             '- Build the MSI installer (and the Portable '
                             'App): `cd build ; cpack`\r\n'
                             '\r\n'
                             '## __SQL Remote Database Drivers__\r\n'
                             '\r\n'
                             'MySQL plugins are not shipped with QT anymore '
                             'because of license issues.\r\n'
                             '\r\n'
                             '### Linux\r\n'
                             '\r\n'
                             '- Debian: `libqt6sql6-psql` `libqt6sql6-mysql` '
                             'or `libqt6sql6-odbc`.\r\n'
                             '- RPM: `libqt6-database-plugin-pgsql` '
                             '`libqt6-database-plugin-mysql` '
                             '`libqt6-database-plugin-odbc`\r\n'
                             '\r\n'
                             'They should pull in all necessary '
                             'dependencies.\r\n'
                             '\r\n'
                             '### Apple macos\r\n'
                             '\r\n'
                             '- **PostgreSQL**: Driver included since XCA '
                             '2.9.0\r\n'
                             '- **ODBC**: It requires the '
                             '`/usr/local/opt/libiodbc/lib/libiodbc.2.dylib`.\r\n'
                             '    When installing unixodbc via `brew` the '
                             'library must be symlinked from\r\n'
                             '    '
                             '`/opt/homebrew/Cellar/libiodbc/3.52.16/lib/libiodbc.2.dylib`\r\n'
                             '- **MariaDB**: Driver included since XCA '
                             '2.8.0\r\n'
                             '\r\n'
                             '### Windows\r\n'
                             '\r\n'
                             '- **PostgreSQL**: '
                             'https://www.enterprisedb.com/downloads/postgres-postgresql-downloads '
                             '(Commandline tools).\r\n'
                             '  Add the `bin` directory of the Postgres '
                             'installation directory to your PATH '
                             '(C:\\\\Program Files\\\\PostgreSQL\\\\16)\r\n'
                             '- **ODBC**: Use the `ODBC Datasources 64bit app` '
                             'to configure the SQL Server\r\n'
                             '- **MariaDB (MySQL)**: Install the Plugin from '
                             'here: '
                             'https://github.com/thecodemonkey86/qt_mysql_driver.\r\n'
                             '  Select the MinGW variant and install it as '
                             'documented.\r\n',
            'url': 'https://github.com/chris2511/xca/releases/download/RELEASE.2.9.0/xca-2.9.0-Darwin.dmg',
            'version': 'RELEASE.2.9.0'}}
URLDownloader
{'Input': {'filename': 'xca-RELEASE.2.9.0.dmg',
           'url': 'https://github.com/chris2511/xca/releases/download/RELEASE.2.9.0/xca-2.9.0-Darwin.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 28 Mar 2025 20:41:38 GMT
URLDownloader: Storing new ETag header: "0x8DD6E38F02960B8"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg
{'Output': {'download_changed': True,
            'etag': '"0x8DD6E38F02960B8"',
            'last_modified': 'Fri, 28 Mar 2025 20:41:38 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg/xca.app',
           'requirement': 'identifier "de.hohnstaedt.xca" and anchor apple '
                          'generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'HWR8GSJ73M'}}
CodeSignatureVerifier: No value supplied for deep_verification, setting default value of: True
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.uDNBi0/xca.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.uDNBi0/xca.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.uDNBi0/xca.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg/xca.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg
Versioner: Found version 2.9.0 in file ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg/xca.app/Contents/Info.plist
{'Output': {'version': '2.9.0'}}
AppPkgCreator
{'Input': {'version': '2.9.0'}}
AppPkgCreator: No value supplied for version_key, setting default value of: CFBundleShortVersionString
AppPkgCreator: No value supplied for force_pkg_build, setting default value of: False
AppPkgCreator: Mounted disk image ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg
AppPkgCreator: Using path '/private/tmp/dmg.R5Y870/xca.app' matched from globbed '/private/tmp/dmg.R5Y870/*.app'.
AppPkgCreator: BundleID: de.hohnstaedt.xca
AppPkgCreator: Copied /private/tmp/dmg.R5Y870/xca.app to ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/payload/Applications/xca.app
AppPkgCreator: Connecting
AppPkgCreator: Sending packaging request
AppPkgCreator: Disconnecting
{'Output': {'app_pkg_creator_summary_result': {'data': {'identifier': 'de.hohnstaedt.xca',
                                                        'pkg_path': '~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/xca-2.9.0.pkg',
                                                        'version': '2.9.0'},
                                               'report_fields': ['identifier',
                                                                 'version',
                                                                 'pkg_path'],
                                               'summary_text': 'The following '
                                                               'packages were '
                                                               'built:'},
            'new_package_request': True,
            'version': '2.9.0'}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/receipts/xca.pkg-receipt-20251025-225709.plist

The following new items were downloaded:
    Download Path                                                                                       
    -------------                                                                                       
    ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/downloads/xca-RELEASE.2.9.0.dmg  

The following packages were built:
    Identifier         Version  Pkg Path                                                                          
    ----------         -------  --------                                                                          
    de.hohnstaedt.xca  2.9.0    ~/Library/AutoPkg/Cache/com.github.Lotusshaney.pkg.xca/xca-2.9.0.pkg
```