### PR TITLE
Deprecate NextCloud recipes

### DIFF
--- a/Nextcloud/Nextcloud.download.recipe
+++ b/Nextcloud/Nextcloud.download.recipe
@@ -21,7 +21,7 @@
 				<key>Arguments</key>
 				<dict>
 					<key>warning_message</key>
-					<string>Consider switching to the NextCloud recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+					<string>Consider switching to the NextCloud download or munki recipes in the peterkelm-recipes repo or the NextCloud pkg recipe in the andredb90-recipes repo. This recipe is deprecated and will be removed in the future.</string>
 				</dict>
 			</dict>
 			<dict>

--- a/Nextcloud/Nextcloud.download.recipe
+++ b/Nextcloud/Nextcloud.download.recipe
@@ -12,9 +12,18 @@
 			<string>NextCloud</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>1.0.4</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the NextCloud recipes in the peterkelm-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Arguments</key>
 				<dict>


### PR DESCRIPTION
The NextCloud recipes in this repo is similar in function to the earlier-created ones in peterkelm-recipes (download, munki) and andredb90-recipes (pkg). This PR deprecates the ones in this repo.

This consolidation will help simplify search results and lower maintenance effort. Thank you!