### PR TITLE
Update AdobeCreativeCloudInstallerUniversal.download.recipe

### DIFF
--- a/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
+++ b/AdobeCreativeCloud/AdobeCreativeCloudInstallerUniversal.download.recipe
@@ -20,9 +20,9 @@
 		<key>SEARCH_URL</key>
 		<string>https://helpx.adobe.com/download-install/apps/download-install-apps/creative-cloud-apps/download-creative-cloud-desktop-app-using-direct-links.html</string>
 		<key>INTEL_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%INTEL_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>APPLE_SILICON_SEARCH_PATTERN</key>
-		<string>(?P&lt;url&gt;http.*?://ccmdls.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
+		<string>(?P&lt;url&gt;http.*?://ccmdl.adobe.com/AdobeProducts/StandaloneBuilds/ACCC/ESD/.*?/.*?/%APPLE_SILICON_ARCHITECTURE%/ACCC.*?.dmg)</string>
 		<key>INTEL_ARCHITECTURE</key>
 		<string>osx10</string>
 		<key>APPLE_SILICON_ARCHITECTURE</key>


### PR DESCRIPTION
Adobe decided to change their download URL pattern from using `https://cmdls.adobe` to `https://cmdl.adobe`