### PR TITLE
Deprecate arch-specific Smallstep CLI recipes

### DIFF
--- a/SmallStep/step_cli.download.recipe
+++ b/SmallStep/step_cli.download.recipe
@@ -16,9 +16,18 @@
 			<string>arm64</string>
 		</dict>
 		<key>MinimumVersion</key>
-		<string>1.0.0</string>
+		<string>1.1</string>
 		<key>Process</key>
 		<array>
+			<dict>
+				<key>Processor</key>
+				<string>DeprecationWarning</string>
+				<key>Arguments</key>
+				<dict>
+					<key>warning_message</key>
+					<string>Consider switching to the step_cli_uni recipes in this repo or the arch-specific step_cli recipes in the fishd72-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+				</dict>
+			</dict>
 			<dict>
 				<key>Processor</key>
 				<string>GitHubReleasesInfoProvider</string>


### PR DESCRIPTION
The architecture-specific Smallstep CLI recipes in this repo are similar in function to the earlier-created ones in fishd72-recipes. This PR deprecates these recipes, while leaving the "universal" recipes that combine the Apple Silicon and Intel Smallstep CLI installers.

This consolidation will help simplify search results and lower maintenance effort. Thank you!