### PR TITLE
Glean.pkg.recipe: use FileFinder for component package discovery

### DIFF
--- a/Glean/Glean.pkg.recipe
+++ b/Glean/Glean.pkg.recipe
@@ -31,10 +31,19 @@
 		<dict>
 			<key>Arguments</key>
 			<dict>
+				<key>pattern</key>
+				<string>%RECIPE_CACHE_DIR%/unpacked/*/Payload</string>
+			</dict>
+			<key>Processor</key>
+			<string>FileFinder</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
 				<key>destination_path</key>
 				<string>%RECIPE_CACHE_DIR%/payload</string>
 				<key>pkg_payload_path</key>
-				<string>%RECIPE_CACHE_DIR%/unpacked/com.glean.desktop.pkg/Payload</string>
+				<string>%found_filename%</string>
 				<key>purge_destination</key>
 				<true/>
 			</dict>


### PR DESCRIPTION
Glean's upstream installer changed its internal component package name from `com.glean.desktop.pkg` to `Glean-component.pkg`, breaking the hardcoded path in `PkgPayloadUnpacker`. Use `FileFinder` to discover the `Payload` path dynamically so the recipe is resilient to future component name changes.