### PR TITLE
Fix misplaced processor arguments

### DIFF
--- a/Wireshark-Universal/Wireshark-Universal.pkg.recipe
+++ b/Wireshark-Universal/Wireshark-Universal.pkg.recipe
@@ -198,12 +198,12 @@ exit 0</string>
 						<string>org.wireshark.Wireshark.pkg</string>
 						<key>pkgdir</key>
 						<string>%RECIPE_CACHE_DIR%</string>
+						<key>scripts</key>
+						<string>%RECIPE_CACHE_DIR%/arm_scripts</string>
 					</dict>
 					<key>pkgname</key>
 					<string>%NAME%-Arm-%version%</string>
 				</dict>
-				<key>scripts</key>
-				<string>%RECIPE_CACHE_DIR%/arm_scripts</string>
 				<key>Processor</key>
 				<string>PkgCreator</string>
 			</dict>


### PR DESCRIPTION
This PR ensures that typos or indentation doesn't prevent Arguments from being properly detected within each Processor.

Thanks for considering!

This PR was submitted using [Repo Lasso](https://github.com/homebysix/repo-lasso) v1.3.0.