### PR TITLE
Deprecate Zoom recipes

### DIFF
--- a/Zoom/Zoom.download.recipe
+++ b/Zoom/Zoom.download.recipe
@@ -21,6 +21,15 @@
     <array>
         <dict>
             <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>Consider switching to Zoom recipes in the hansen-m-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
             <string>URLDownloader</string>
             <key>Arguments</key>
             <dict>


### PR DESCRIPTION
Per the AutoPkg [repo maintenance expectations](https://github.com/autopkg/autopkg/wiki/Sharing-Recipes#repo-maintenance-expectations), duplicate recipes can appear in search results and cause confusion, especially for people getting started with AutoPkg. Consolidating in favor of recipes with the broadest utility helps reduce that noise.

This repo's Zoom download recipe is functionally equivalent to the [Zoom download recipe in hansen-m-recipes](https://github.com/autopkg/hansen-m-recipes/blob/master/Zoom/Zoom.download.recipe) — both fetch the same IT Admins package from the same URL and verify the same signing authorities. The hansen-m recipe predates the download recipe in this repo, is referenced by a number of child recipes across several repos, and remains actively maintained, which makes it a natural point to consolidate around.

This consolidation will help simplify search results and lower maintenance effort. Thank you for considering!